### PR TITLE
fix(core,react): hide cookie banner when customizing consent

### DIFF
--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -100,7 +100,7 @@ export interface PrivacyConsentState {
 	 * Controls the visibility of the consent popup.
 	 * @param show - Whether to show the popup
 	 */
-	setShowPopup: (show: boolean) => void;
+	setShowPopup: (show: boolean, force?: boolean) => void;
 
 	/**
 	 * Controls the visibility of the privacy dialog.

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -109,12 +109,12 @@ export interface PrivacyConsentState {
 	 * Controls the visibility of the consent popup.
 	 * @param show - Whether to show the popup
 	 */
- /**
-  * Controls the visibility of the consent popup.
-  * @param show - Whether to show the popup
-  * @param force - When true, forcefully updates the popup state regardless of current consent customization
-  */
- setShowPopup: (show: boolean, force?: boolean) => void;
+	/**
+	 * Controls the visibility of the consent popup.
+	 * @param show - Whether to show the popup
+	 * @param force - When true, forcefully updates the popup state regardless of current consent customization
+	 */
+	setShowPopup: (show: boolean, force?: boolean) => void;
 
 	/**
 	 * Controls the visibility of the privacy dialog.

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -100,7 +100,12 @@ export interface PrivacyConsentState {
 	 * Controls the visibility of the consent popup.
 	 * @param show - Whether to show the popup
 	 */
-	setShowPopup: (show: boolean, force?: boolean) => void;
+ /**
+  * Controls the visibility of the consent popup.
+  * @param show - Whether to show the popup
+  * @param force - When true, forcefully updates the popup state regardless of current consent customization
+  */
+ setShowPopup: (show: boolean, force?: boolean) => void;
 
 	/**
 	 * Controls the visibility of the privacy dialog.

--- a/packages/react/src/primitives/button.tsx
+++ b/packages/react/src/primitives/button.tsx
@@ -87,7 +87,7 @@ export const ConsentButton = forwardRef<
 					break;
 				case 'open-consent-dialog': {
 					setIsPrivacyDialogOpen(true);
-					setShowPopup(false);
+					setShowPopup(false, true);
 					break;
 				}
 				default:


### PR DESCRIPTION
## Overview
Hide cookie banner when customizing consent

## Related Issue
Fixes #76 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced privacy consent interaction: The popup now supports an additional control option for managing its display. This update improves the consistency and reliability of how the consent popup behaves, especially when users interact with consent buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->