### PR TITLE
feat(core,react): add noStyle option to  ConsentManagerProvider

### DIFF
--- a/packages/core/src/store.initial-state.ts
+++ b/packages/core/src/store.initial-state.ts
@@ -96,6 +96,9 @@ export const initialState: Omit<
 	/** Default translation configuration */
 	translationConfig: defaultTranslationConfig,
 
+	/** Default styling enabled */
+	noStyle: false,
+
 	/** Don't include non-displayed consents by default */
 	includeNonDisplayedConsents: false,
 
@@ -116,6 +119,7 @@ export const initialState: Omit<
 	getDisplayedConsents: () => [],
 	hasConsented: () => false,
 	setTranslationConfig: () => {},
+	setNoStyle: () => {},
 	clearAllData: () => {},
 	updateConsentMode: () => {},
 	setPrivacySettings: () => {},

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -437,6 +437,15 @@ export const createConsentManagerStore = (
 		setTranslationConfig: (config: TranslationConfig) => {
 			set({ translationConfig: config });
 		},
+
+		/**
+		 * Updates the noStyle setting.
+		 *
+		 * @param noStyle - Whether to disable default styling
+		 */
+		setNoStyle: (noStyle) => {
+			set({ noStyle });
+		},
 	}));
 
 	if (typeof window !== 'undefined') {

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -77,11 +77,20 @@ export interface PrivacyConsentState {
 	/** Translation configuration */
 	translationConfig: TranslationConfig;
 
+	/** Whether to disable all default styling */
+	noStyle?: boolean;
+
 	/**
 	 * Updates the translation configuration.
 	 * @param config - The new translation configuration
 	 */
 	setTranslationConfig: (config: TranslationConfig) => void;
+
+	/**
+	 * Updates the noStyle setting.
+	 * @param noStyle - Whether to disable default styling
+	 */
+	setNoStyle: (noStyle: boolean) => void;
 
 	/** Whether to include non-displayed consents in operations */
 	includeNonDisplayedConsents: boolean;

--- a/packages/react/src/common/components/consent-manager-provider.tsx
+++ b/packages/react/src/common/components/consent-manager-provider.tsx
@@ -56,15 +56,23 @@ export function ConsentManagerProvider({
 		});
 		// Set translation config immediately
 		store.getState().setTranslationConfig(preparedTranslationConfig);
+
+		// Set noStyle immediately
+		store.getState().setNoStyle(noStyle);
+
 		return store;
-	}, [namespace, preparedTranslationConfig, trackingBlockerConfig]);
+	}, [namespace, preparedTranslationConfig, trackingBlockerConfig, noStyle]);
 
 	// Initialize state with the current state from the consent manager store
 	const [state, setState] = useState<PrivacyConsentState>(store.getState());
 
 	useEffect(() => {
-		const { setGdprTypes, setComplianceSetting, setDetectedCountry } =
-			store.getState();
+		const {
+			setGdprTypes,
+			setComplianceSetting,
+			setDetectedCountry,
+			setNoStyle,
+		} = store.getState();
 
 		// Initialize GDPR types if provided
 		if (initialGdprTypes) {
@@ -79,6 +87,9 @@ export function ConsentManagerProvider({
 				setComplianceSetting(region as ComplianceRegion, settings);
 			}
 		}
+
+		// Update noStyle when prop changes
+		setNoStyle(noStyle);
 
 		// Set detected country
 		const country =
@@ -96,7 +107,7 @@ export function ConsentManagerProvider({
 		return () => {
 			unsubscribe();
 		};
-	}, [store, initialGdprTypes, initialComplianceSettings]);
+	}, [store, initialGdprTypes, initialComplianceSettings, noStyle]);
 
 	// Memoize the context value to prevent unnecessary re-renders
 	const contextValue = useMemo(

--- a/packages/react/src/common/utils/theme.ts
+++ b/packages/react/src/common/utils/theme.ts
@@ -16,6 +16,7 @@ export function createThemeContextValue(
 	const result = Object.assign(fn, {
 		...consentManager,
 		...themeProps,
+		noStyle: themeProps.noStyle ?? consentManager.noStyle,
 	});
 
 	// Type guard to ensure type safety


### PR DESCRIPTION
## Overview
Added nostyle prop to the provider

```
// All components will be noStyled
<ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']} noStyle>
  <CookieBanner />
  <ConsentManagerDialog />
  {children}
</ConsentManagerProvider>

// Only cookie banner will be noStyled
<ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']}>
<CookieBanner noStyle />
<ConsentManagerDialog />
{children}
</ConsentManagerProvider>

// Dialog  will be unstyled  but cookie banner will retain its default styles
<ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']} noStyle>
<CookieBanner noStyle={false} />
<ConsentManagerDialog />
{children}
</ConsentManagerProvider>
```
## Related Issue
Fixes #80 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a styling toggle option that lets users disable the default appearance.
  - Enabled dynamic updating of the styling configuration within the consent management system.
  - Enhanced the theming context to integrate and reflect changes in styling preference immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->