### PR TITLE
docs(core,react): Add API reference documentation

### DIFF
--- a/apps/docs/src/content/core/api-reference.mdx
+++ b/apps/docs/src/content/core/api-reference.mdx
@@ -3,17 +3,56 @@ title: API Reference
 description: Comprehensive guide to using the c15t package for managing privacy consents.
 ---
 
+# Core Package API Reference
 
-### createConsentManagerStore
+The core package (`c15t`) provides the fundamental functionality for managing privacy consents in your application. This reference documents the main types, interfaces, and functions available in the package.
 
-Creates a new consent manager store instance.
+## Store API
 
-**Parameters:**
-- `namespace` (optional): A string to namespace the store instance.
+The core package implements a robust state management system for handling privacy consents. The store provides methods for:
 
-**Returns:** A Zustand store instance with consent management functionality.
+- Managing consent states
+- Persisting consent data
+- Validating consent configurations
 
+For detailed implementation examples, refer to the [Getting Started](/core/getting-started) guide.
 
-### Store State
+## Privacy Consent State
+
+The `PrivacyConsentState` type represents the current state of privacy consents in your application. It contains information about user preferences, consent categories, and their respective settings.
 
 <AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
+
+## Consent Types
+
+The `ConsentType` type defines the structure of individual consent categories and their properties.
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ConsentType" />
+
+## Translation Configuration
+
+The `defaultTranslationConfig` provides the default translation settings for the consent management interface.
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="defaultTranslationConfig" />
+
+## Tracking Blocker Configuration
+
+The `TrackingBlockerConfig` type defines the configuration options for the tracking blocker functionality.
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="TrackingBlockerConfig" />
+
+## Additional Types
+
+### Consent State
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ConsentState" />
+
+### Compliance Settings
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ComplianceSettings" />
+
+### Privacy Settings
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacySettings" />
+
+### Translation Types
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="TranslationConfig" />
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="Translations" />
+

--- a/apps/docs/src/content/framework/react/api-reference.mdx
+++ b/apps/docs/src/content/framework/react/api-reference.mdx
@@ -1,0 +1,158 @@
+---
+title: API Reference
+description: The @c15t/react package provides a React-specific components and hooks for managing privacy consents.
+---
+
+## `useConsentManager`
+
+The `useConsentManager` hook is used to access the consent manager state and methods.
+
+**Example Usage**
+
+```tsx
+import { useConsentManager } from "@c15t/react";
+
+export default function Page() {
+  const { resetConsents } = useConsentManager();
+
+  return (
+    <>
+      {/* ... */}
+      <button onClick={resetConsents}>
+        Reset Consents
+      </button>
+    </>
+  );
+```
+
+**Returns**
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
+
+## `useTranslations`
+
+The `useTranslations` hook is used to translate the text of the consent manager. [See the internationalization guide for more information.](/framework/react/internationalization)
+
+**Example Usage**
+
+```tsx
+import * as CookieBanner from "@c15t/react";
+import { useTranslations } from "@c15t/react";
+
+export default function CookieBanner() {
+  const { cookieBanner } = useTranslations();
+  
+	return (
+		<CookieBanner.Root>
+			<CookieBanner.Card>
+				<CookieBanner.Header>
+					<CookieBanner.Title>{cookieBanner.title}</CookieBanner.Title>
+					<CookieBanner.Description>{cookieBanner.description}</CookieBanner.Description>
+				</CookieBanner.Header>
+                {/* ... */}
+			</CookieBanner.Card>
+		</CookieBanner.Root>
+	);
+}
+```
+
+**Returns**
+
+Returns a `Translations` object containing all the text strings used, organized by component:
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="Translations" />
+
+## `ConsentManagerProvider`
+
+The `ConsentManagerProvider` component is used to provide the consent manager context to the components that need it.
+
+**Props**
+<AutoTypeTable path="node_modules/@c15t/react/src/index.ts" name="ConsentManagerProviderProps" />
+
+**Example Usage**
+
+```tsx
+import { ConsentManagerProvider, CookieBanner, ConsentManagerDialog } from "@c15t/react";
+
+export default function App() {
+  return (
+    <ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']}>
+      <CookieBanner />
+      <ConsentManagerDialog />
+    </ConsentManagerProvider>
+  );
+}
+```
+
+## `CookieBanner`
+
+The `CookieBanner` component is used to display the cookie banner. [See the cookie banner guide for more information.](/framework/react/cookie-banner)
+
+**Props**
+<AutoTypeTable path="node_modules/@c15t/react/src/index.ts" name="CookieBannerProps" />
+
+**Example Usage**
+
+```tsx
+import { ConsentManagerProvider, CookieBanner, ConsentManagerDialog } from "@c15t/react";
+
+export default function App() {
+  return (
+    <ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']}>
+      <CookieBanner />
+      <ConsentManagerDialog />
+    </ConsentManagerProvider>
+  );
+}
+```
+
+## `ConsentManagerDialog`
+
+The `ConsentManagerDialog` component is used to display the consent manager in a dialog. [See the consent manager dialog guide for more information.](/framework/react/consent-manager-dialog)
+
+**Props**
+<AutoTypeTable path="node_modules/@c15t/react/src/index.ts" name="ConsentManagerDialogProps" />
+
+**Example Usage**
+
+```tsx
+import { ConsentManagerProvider, CookieBanner, ConsentManagerDialog } from "@c15t/react";
+
+export default function App() {
+  return (
+    <ConsentManagerProvider initialGdprTypes={['necessary', 'marketing']}>
+      <CookieBanner />
+      <ConsentManagerDialog />
+    </ConsentManagerProvider>
+  );
+}
+```
+
+## `ConsentManagerWidget`
+
+This component is the core interface for detailed privacy consent management, enabling users to fine-tune their privacy preferences through an intuitive accordion interface. [Learn more](/framework/react/consent-manager-widget)
+
+**Props**
+<AutoTypeTable path="node_modules/@c15t/react/src/index.ts" name="ConsentManagerWidgetProps" />
+
+**Example Usage**
+
+```tsx
+import { ConsentManagerWidget } from "@c15t/react";
+
+export default function CustomConsentWidget() {
+  return (
+    <ConsentManagerWidget>
+      <ConsentManagerWidget.AccordionItems />
+      <ConsentManagerWidget.Footer>
+        <ConsentManagerWidget.RejectButton>
+          Deny
+        </ConsentManagerWidget.RejectButton>
+        <ConsentManagerWidget.AcceptAllButton>
+          Accept All
+        </ConsentManagerWidget.AcceptAllButton>
+      </ConsentManagerWidget.Footer>
+    </ConsentManagerWidget>
+  );
+}
+```

--- a/apps/docs/src/content/framework/react/meta.json
+++ b/apps/docs/src/content/framework/react/meta.json
@@ -4,6 +4,7 @@
 	"pages": [
 		"--- Introduction ---",
 		"index",
+		"api-reference",
 		"--- Components ---",
 		"cookie-banner",
 		"consent-manager-widget",


### PR DESCRIPTION
## Overview
- Expanded API documentation for both core and React packages:
- Created detailed API reference for core package types and interfaces
- Added React package API reference with comprehensive component and hook descriptions
- Included type tables for key types like PrivacyConsentState, ConsentType, and Translations
- Updated framework/react meta.json to include new API reference page

## Related Issue
Fixes #84 

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Redesigned the API reference for the core package with a clearer structure and comprehensive overviews for managing privacy consents.
  - Introduced detailed API documentation for the React package, showcasing new tools and usage examples.
  - Updated the documentation navigation to include an API reference section.

- **New Features**
  - Launched new hooks and components to enhance consent management integration within React applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->