### PR TITLE
docs(react): useConsentManager hook documentation + sandpack multi-page support

### DIFF
--- a/apps/docs/src/components/docs/preview/index.tsx
+++ b/apps/docs/src/components/docs/preview/index.tsx
@@ -18,14 +18,12 @@ import {
 import { cn } from '@c15t/shadcn/libs';
 import { AppWindowIcon, CodeIcon, TerminalIcon } from 'lucide-react';
 import type { ComponentProps } from 'react';
-import { exampleContent } from '~/examples/cookie-banner/example-page';
 import { PreviewProvider } from './provider';
 import { tsconfig } from './tsconfig';
 import { utils } from './utils';
-
 type PreviewProps = {
 	name: string;
-	code: string;
+	code: string | Record<string, string>;
 	dependencies?: Record<string, string>;
 };
 
@@ -49,10 +47,17 @@ export const Preview = ({
 	const devDependencies: Record<string, string> = {};
 
 	const files: ComponentProps<typeof SandboxProvider>['files'] = {
-		'/App.tsx': code,
 		'/tsconfig.json': tsconfig,
 		'/lib/utils.ts': utils,
-		'/exampleContent.tsx': exampleContent,
+		...(typeof code === 'string'
+			? { '/App.tsx': code }
+			: Object.entries(code).reduce(
+					(acc, [filename, content]) =>
+						Object.assign(acc, {
+							[filename.startsWith('/') ? filename : `/${filename}`]: content,
+						}),
+					{}
+				)),
 	};
 
 	// Scan the demo code for any imports of shadcn/ui components

--- a/apps/docs/src/components/docs/preview/utils.ts
+++ b/apps/docs/src/components/docs/preview/utils.ts
@@ -1,6 +1,30 @@
-export const utils = `import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+export const utils = `
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}`;
+	return twMerge(clsx(inputs));
+}
+
+export function setupDarkMode() {
+	const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+	const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+		document.documentElement.classList.toggle('dark', e.matches);
+		document.documentElement.classList.toggle('light', !e.matches);
+	};
+
+	handleChange(mediaQuery);
+	mediaQuery.addEventListener('change', handleChange);
+	return () => mediaQuery.removeEventListener('change', handleChange);
+}
+
+export function clearLocalStorage() {
+	if (typeof window !== 'undefined') {
+		try {
+			localStorage.clear();
+		} catch (error) {
+			console.warn('Error during cleanup:', error);
+		}
+	}
+}
+`;

--- a/apps/docs/src/content/framework/react/meta.json
+++ b/apps/docs/src/content/framework/react/meta.json
@@ -10,6 +10,7 @@
 		"consent-manager-widget",
 		"consent-manager-dialog",
 		"dev-tool",
+		"use-consent-manager",
 		"--- Guides ---",
 		"guides/customization",
 		"guides/translation"

--- a/apps/docs/src/content/framework/react/use-consent-manager.mdx
+++ b/apps/docs/src/content/framework/react/use-consent-manager.mdx
@@ -1,0 +1,25 @@
+---
+title: useConsentManager
+description: The useConsentManager hook provides access to the complete consent management API, allowing you to interact with and control the consent state throughout your application.
+---
+import UseConsentManagerExample from '../../../examples/use-consent-manager';
+
+## Usage
+
+This example shows the hook being used to re-open the cookie banner once it has been closed. This could be used to re-open the banner after a certain amount of time has passed, or when a user wishes to update their consents for example.
+
+<UseConsentManagerExample/>
+
+## Returns
+
+The hook returns an object containing both state properties and methods for managing consent:
+
+<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
+
+## Notes
+
+- The hook must be used within a `ConsentManagerProvider` component
+- Throws an error if used outside of a `ConsentManagerProvider`
+- All methods are memoized and safe to use in effects or callbacks
+- Changes to consent state are automatically persisted
+- Supports TypeScript with full type safety

--- a/apps/docs/src/examples/cookie-banner/index.tsx
+++ b/apps/docs/src/examples/cookie-banner/index.tsx
@@ -1,8 +1,6 @@
 import { Preview } from '~/components/docs/preview';
-import { defaultPage } from './example-page';
+import { pages } from './example-page';
 
-const CookieBannerExample = () => {
-	return <Preview name="sandbox" code={defaultPage} />;
-};
-
-export default CookieBannerExample;
+export default function UseConsentManagerExample() {
+	return <Preview name="sandbox" code={pages} />;
+}

--- a/apps/docs/src/examples/use-consent-manager/example.tsx
+++ b/apps/docs/src/examples/use-consent-manager/example.tsx
@@ -9,7 +9,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            initialGdprTypes={['necessary', 'marketing']}
+            initialGdprTypes={['necessary', 'marketing', 'analytics']}
         >
             <CookieBanner />
             <ConsentManagerDialog />
@@ -30,6 +30,13 @@ export function ExampleContent() {
 
     return (
         <div className="min-h-screen flex flex-col justify-center items-center gap-4 dark:bg-[#18191c] p-4">
+            <button 
+                onClick={() => setShowPopup(true)} 
+                className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md transition-colors"
+            >
+                Open Cookie Settings
+            </button>
+            
          	  <main className="mx-auto max-w-2xl text-center">
 					    <div className="bg-gradient-to-t light:from-black/40 dark:from-white/40 light:to-black/10 dark:to-white/10 bg-clip-text font-bold text-[60px] text-transparent leading-none tracking-tighter">c15t.com</div>
 			      </main>

--- a/apps/docs/src/examples/use-consent-manager/index.tsx
+++ b/apps/docs/src/examples/use-consent-manager/index.tsx
@@ -1,0 +1,8 @@
+import { Preview } from '~/components/docs/preview';
+import { pages } from './example';
+
+const UseConsentManagerExample = () => {
+	return <Preview name="use-consent-manager" code={pages} />;
+};
+
+export default UseConsentManagerExample;


### PR DESCRIPTION

## Overview
- useConsentManager hook docs
- Added multi-page support for sandpack previews

## Related Issue
Fixes #83 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced code previews to support multiple file examples.
  - Introduced dark mode toggling and improved local storage management.
- **Documentation**
  - Added a comprehensive guide for a new consent management hook.
  - Published a new documentation page detailing updated consent management features.
- **Refactor**
  - Streamlined example layouts and restructured components for clearer demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->